### PR TITLE
CAF-2871 Update Auditing Schema XSD Namespace

### DIFF
--- a/caf-audit-maven-plugin/caf-audit-maven-plugin.md
+++ b/caf-audit-maven-plugin/caf-audit-maven-plugin.md
@@ -9,7 +9,7 @@ The XML audit event file used by the custom plugin defines the audit events that
 provided next.
 
 ```xml
-<AuditedApplication xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd">
+<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd">
   <ApplicationId>ProductX</ApplicationId>
   <AuditEvents>
     <AuditEvent>

--- a/caf-audit-maven-plugin/src/test/resources/xml/AuditConfig.xml
+++ b/caf-audit-maven-plugin/src/test/resources/xml/AuditConfig.xml
@@ -18,8 +18,8 @@
 -->
 <AuditedApplication
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
-		xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+		xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
+		xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 >
 	<ApplicationId>ProductX</ApplicationId>
 	<AuditEvents>

--- a/caf-audit-maven-plugin/src/test/resources/xml/InvalidAuditConfig.xml
+++ b/caf-audit-maven-plugin/src/test/resources/xml/InvalidAuditConfig.xml
@@ -18,8 +18,8 @@
 -->
 <AuditedApplication			
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd" 
-    xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"			
+    xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd" 
+    xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"			
 >
 	<ApplicationId>ProductX</ApplicationId>
 	<AuditEvents>

--- a/caf-audit-schema/README.md
+++ b/caf-audit-schema/README.md
@@ -9,9 +9,9 @@ This project contains the exact XML Schema file that the Audit Event Definition 
 An example of an Audit Event Definition File is shown next:
 
 	<?xml version="1.0" encoding="UTF-8"?>
-	<AuditedApplication xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	                    xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
+                        xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
 	  <ApplicationId>SampleApp</ApplicationId>
 	  <AuditEvents>
 	    <AuditEvent>
@@ -67,12 +67,12 @@ If you reference the XML Schema file from your Audit Event Definition File then 
 
 Change the `AuditedApplication` element from:
 
-	<AuditedApplication xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd">
+	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd">
 
 to:
 
-	<AuditedApplication xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	                    xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
-
+                        xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
+                        
 Many IDEs and XML Editors will also use the schema file to provide IntelliSense and type-ahead when the definition file is being authored.

--- a/caf-audit-schema/README.md
+++ b/caf-audit-schema/README.md
@@ -8,9 +8,9 @@ This project contains the exact XML Schema file that the Audit Event Definition 
 
 An example of an Audit Event Definition File is shown next:
 
-	<?xml version="1.0" encoding="UTF-8"?>
-	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
-	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        <?xml version="1.0" encoding="UTF-8"?>
+        <AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                             xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
 	  <ApplicationId>SampleApp</ApplicationId>
 	  <AuditEvents>
@@ -71,7 +71,7 @@ Change the `AuditedApplication` element from:
 
 to:
 
-	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
+        <AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                             xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
                         

--- a/caf-audit-schema/README.md
+++ b/caf-audit-schema/README.md
@@ -72,7 +72,7 @@ Change the `AuditedApplication` element from:
 to:
 
 	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
-	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                             xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
                         
 Many IDEs and XML Editors will also use the schema file to provide IntelliSense and type-ahead when the definition file is being authored.

--- a/caf-audit-schema/README.md
+++ b/caf-audit-schema/README.md
@@ -11,7 +11,7 @@ An example of an Audit Event Definition File is shown next:
 	<?xml version="1.0" encoding="UTF-8"?>
 	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
+                            xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
 	  <ApplicationId>SampleApp</ApplicationId>
 	  <AuditEvents>
 	    <AuditEvent>
@@ -73,6 +73,6 @@ to:
 
 	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                        xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
+                            xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
                         
 Many IDEs and XML Editors will also use the schema file to provide IntelliSense and type-ahead when the definition file is being authored.

--- a/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd
+++ b/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd
@@ -17,8 +17,8 @@
 
 -->
 <schema xmlns="http://www.w3.org/2001/XMLSchema"
-        xmlns:aa="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
-        targetNamespace="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+        xmlns:aa="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
+        targetNamespace="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
         elementFormDefault="qualified">
 
   <element name="AuditedApplication">

--- a/caf-audit/test-case/events.xml
+++ b/caf-audit/test-case/events.xml
@@ -18,8 +18,8 @@
 -->
 <AuditedApplication
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
-    xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+    xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
+    xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 >
     <ApplicationId>TestAuditEvents</ApplicationId>
     <AuditEvents>

--- a/docs/pages/en-us/Getting-Started.md
+++ b/docs/pages/en-us/Getting-Started.md
@@ -64,9 +64,9 @@ A list of parameter elements are then defined for each audit event, including th
 
 If you reference the XML schema file from your audit event definition file, then you should be able to use the validate functionality that is built into most IDEs and XML editors. Validate allows you to easily check for syntax errors in your audit event definition file. Just add the standard `xsi:schemaLocation` attribute to the root `AuditedApplication` element:
 
-	<AuditedApplication xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	                    xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">	                   
+	                    xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">	                   
 
 Many IDEs and XML editors use the schema file to provide IntelliSense / Auto-Complete when authoring the definition file.
 
@@ -75,9 +75,9 @@ Many IDEs and XML editors use the schema file to provide IntelliSense / Auto-Com
 The following is an example of an audit event definition file used throughout this guide:
 
 	<?xml version="1.0" encoding="UTF-8"?>
-	<AuditedApplication xmlns="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd"
+	<AuditedApplication xmlns="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd"
 	                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	                    xsi:schemaLocation="http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
+	                    xsi:schemaLocation="https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd https://raw.githubusercontent.com/CAFAudit/audit-service/v3.0.0/caf-audit-schema/src/main/resources/schema/AuditedApplication.xsd">
 	  <ApplicationId>SampleApp</ApplicationId>
 	  <AuditEvents>
 	    <AuditEvent>


### PR DESCRIPTION
Updated:
* http://www.hpe.com/CAF/Auditing/Schema/AuditedApplication.xsd
TO:
* https://cafaudit.github.io/audit-service/schema/AuditedApplication.xsd