### PR TITLE
CAF-2277: Add HTTPS support to the Audit Web Service

### DIFF
--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -103,6 +103,13 @@
             <artifactId>log4j-core</artifactId>
             <version>2.7</version>
         </dependency>
+        <!--Used to expose HTTPS endpoint-->
+        <dependency>
+            <groupId>com.github.cafapi</groupId>
+            <artifactId>container-cert-script</artifactId>
+            <type>tar.gz</type>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -205,6 +212,7 @@
                         <CAF_ELASTIC_HOST_AND_PORT>${docker.host.address}:${elasticsearch.transport.port}</CAF_ELASTIC_HOST_AND_PORT>
                         <CAF_ELASTIC_CLUSTER_NAME>docker-cluster</CAF_ELASTIC_CLUSTER_NAME>
                         <webserviceurl>http://${docker.host.address}:${webservice.adminport}/${webserviceWarName}/v1</webserviceurl>
+                        <webserviceurlhttps>https://${docker.host.address}:${webservice.https.adminport}/${webserviceWarName}/v1</webserviceurlhttps>
                     </environmentVariables>
                 </configuration>
             </plugin>
@@ -261,6 +269,22 @@
                                         </fileSets>
                                     </inline>
                                 </assembly>
+                            </build>
+                        </image>
+                        <!--Build image for test keystore-->
+                        <image>
+                            <alias>keystore</alias>
+                            <name>${project.artifactId}-keystore:${project.version}</name>
+                            <build>
+                                <from>java:8</from>
+                                <maintainer>connor.mulholland@hpe.com</maintainer>
+                                <runCmds>
+                                    <runCmd>mkdir /test-keystore</runCmd>
+                                    <runCmd>$JAVA_HOME/bin/keytool -genkey -noprompt -alias tomcat -dname "CN=myname, OU=myorganisational.unit, O=myorganisation, L=mycity, S=myprovince, C=GB" -keystore /test-keystore/tomcat.keystore -storepass changeit -keypass changeit -keyalg RSA</runCmd>
+                                </runCmds>
+                                <volumes>
+                                    <volume>/test-keystore</volume>
+                                </volumes>
                             </build>
                         </image>
                         <image>
@@ -328,13 +352,40 @@
                                                 </includes>
                                                 <outputDirectory>/maven</outputDirectory>
                                             </dependencySet>
+                                            <!-- Unpack container-cert-script needed to expose HTTPS endpoint-->
+                                            <dependencySet>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <scope>runtime</scope>
+                                                <useTransitiveDependencies>true</useTransitiveDependencies>
+                                                <useTransitiveFiltering>true</useTransitiveFiltering>
+                                                <excludes>
+                                                    <exclude>com.github.cafapi:container-cert-script</exclude>
+                                                </excludes>
+                                            </dependencySet>
+                                            <dependencySet>
+                                                <includes>
+                                                    <include>com.github.cafapi:container-cert-script</include>
+                                                </includes>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <useTransitiveFiltering>true</useTransitiveFiltering>
+                                                <unpack>true</unpack>
+                                            </dependencySet>
                                         </dependencySets>
+                                        <!-- Overwrite existing tomcat server file (i.e. found in /usr/local/tomcat/conf) with the one -->
+                                        <!-- with the one provided in this project. -->
+                                        <files>
+                                            <file>
+                                                <source>src/main/resources/server.xml</source>
+                                                <outputDirectory>/usr/local/tomcat/conf</outputDirectory>
+                                            </file>
+                                        </files>
                                     </inline>
                                 </assembly>
                             </build>
                             <run>
                                 <ports>
                                     <port>${webservice.adminport}:8080</port>
+                                    <port>${webservice.https.adminport}:8443</port>
                                 </ports>
                                 <env>
                                     <CAF_APPNAME>test/auditservice</CAF_APPNAME>
@@ -342,10 +393,12 @@
                                     <CAF_ELASTIC_HOST_AND_PORT>${docker.host.address}:${elasticsearch.transport.port}</CAF_ELASTIC_HOST_AND_PORT>
                                     <CAF_ELASTIC_CLUSTER_NAME>docker-cluster</CAF_ELASTIC_CLUSTER_NAME>
                                     <DOCKER_HOST>http://172.17.0.1:2375</DOCKER_HOST>
+                                    <SSL_TOMCAT_CA_CERT_LOCATION>/test-keystore/tomcat.keystore</SSL_TOMCAT_CA_CERT_LOCATION>
                                 </env>
                                 <volumes>
                                     <from>
                                         <image>config</image>
+                                        <image>keystore</image>
                                     </from>
                                 </volumes>
                                 <links>

--- a/caf-audit-service-container/src/integration-test/java/com/hpe/caf/services/audit/api/AuditIT.java
+++ b/caf-audit-service-container/src/integration-test/java/com/hpe/caf/services/audit/api/AuditIT.java
@@ -34,11 +34,23 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import javax.net.ssl.*;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.text.*;
-import java.util.*;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TimeZone;
+import java.util.UUID;
 
 public class AuditIT {
     private static String AUDIT_WEBSERVICE_HTTP_BASE_PATH;

--- a/caf-audit-service-container/src/integration-test/java/com/hpe/caf/services/audit/api/AuditIT.java
+++ b/caf-audit-service-container/src/integration-test/java/com/hpe/caf/services/audit/api/AuditIT.java
@@ -33,11 +33,16 @@ import org.joda.time.Instant;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import javax.net.ssl.*;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.text.*;
 import java.util.*;
 
 public class AuditIT {
-    private static String AUDIT_WEBSERVICE_BASE_PATH;
+    private static String AUDIT_WEBSERVICE_HTTP_BASE_PATH;
+    private static String AUDIT_WEBSERVICE_HTTPS_BASE_PATH;
     private static String CAF_ELASTIC_HOST_AND_PORT;
     private static String CAF_ELASTIC_CLUSTER_NAME;
 
@@ -46,16 +51,102 @@ public class AuditIT {
     @BeforeClass
     public static void setup() throws Exception {
         //  Read environment variable settings
-        AUDIT_WEBSERVICE_BASE_PATH = System.getenv("webserviceurl");
+        AUDIT_WEBSERVICE_HTTP_BASE_PATH = System.getenv("webserviceurl");
+        AUDIT_WEBSERVICE_HTTPS_BASE_PATH = System.getenv("webserviceurlhttps");
+
         CAF_ELASTIC_HOST_AND_PORT = System.getenv("CAF_ELASTIC_HOST_AND_PORT");
         CAF_ELASTIC_CLUSTER_NAME = System.getenv("CAF_ELASTIC_CLUSTER_NAME");
 
         auditEventsApi = new AuditEventsApi();
-        auditEventsApi.getApiClient().setBasePath(AUDIT_WEBSERVICE_BASE_PATH);
     }
 
     @Test
     public void testAuditEventsPost() throws Exception {
+        auditEventsApi.getApiClient().setBasePath(AUDIT_WEBSERVICE_HTTP_BASE_PATH);
+        postNewAuditEvent();
+    }
+
+    @Test
+    public void testAuditEventsPost_Https() throws Exception {
+        disableSSLVerification();
+        auditEventsApi.getApiClient().setBasePath(AUDIT_WEBSERVICE_HTTPS_BASE_PATH);
+        postNewAuditEvent();
+    }
+
+    @Test
+    public void testAuditEventsPost_FixedFieldNotProvided() {
+        //  Create new audit event message with at least one fixed field missing.
+        NewAuditEvent auditEventMessage = createNewAuditEventExcludeFixedField();
+        try {
+            auditEventsApi.auditeventsPost(auditEventMessage);
+        } catch (ApiException ae) {
+            Assert.assertEquals(ae.getMessage(),"The application identifier has not been specified");
+        }
+    }
+
+    @Test
+    public void testAuditEventsPost_CustomsFieldsNotProvided() {
+        //  Create new audit event message with no custom fields specified.
+        NewAuditEvent auditEventMessage = createNewAuditEventExcludeCustomFields();
+        try {
+            auditEventsApi.auditeventsPost(auditEventMessage);
+        } catch (ApiException ae) {
+            Assert.assertEquals(ae.getMessage(),"Custom audit event fields have not been specified");
+        }
+    }
+
+    /**
+     * Disable Certificate Validation in Java SSL Connections.
+     */
+    private static void disableSSLVerification() {
+        // Set up a trust-all cert manager implementation
+        TrustManager[] trustAllCertsManager = new TrustManager[]{
+                new X509TrustManager()
+                {
+                    @Override
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers()
+                    {
+                        System.out.println("Trust All TrustManager getAcceptedIssuers() called");
+                        return null;
+                    }
+
+                    @Override
+                    public void checkClientTrusted(
+                            java.security.cert.X509Certificate[] certs, String authType)
+                    {
+                        System.out.println("Trust All TrustManager checkClientTrusted() called");
+                    }
+
+                    @Override
+                    public void checkServerTrusted(
+                            java.security.cert.X509Certificate[] certs, String authType)
+                    {
+                        System.out.println("Trust All TrustManager CheckServerTrusted() called");
+                    }
+                }
+        };
+
+        SSLContext sc;
+        try {
+            // Install the all-trusting trust manager.
+            sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCertsManager, new java.security.SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+
+            // Create all-trusting host name verifier.
+            HostnameVerifier allHostsValid = (hostname, session) -> true;
+
+            // Install the all-trusting host verifier.
+            HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Sends a new audit event message to Elasticsearch.
+     */
+    private void postNewAuditEvent() throws Exception {
         //  Create new audit event message and index into Elasticsearch.
         final NewAuditEvent auditEventMessage = createNewAuditEvent();
         auditEventsApi.auditeventsPost(auditEventMessage);
@@ -85,28 +176,6 @@ public class AuditIT {
 
             //  Delete test document after verification is complete.
             deleteAuditEventMessage(transportClient, esIndex, docId);
-        }
-    }
-
-    @Test
-    public void testAuditEventsPost_FixedFieldNotProvided() {
-        //  Create new audit event message with at least one fixed field missing.
-        NewAuditEvent auditEventMessage = createNewAuditEventExcludeFixedField();
-        try {
-            auditEventsApi.auditeventsPost(auditEventMessage);
-        } catch (ApiException ae) {
-            Assert.assertEquals(ae.getMessage(),"The application identifier has not been specified");
-        }
-    }
-
-    @Test
-    public void testAuditEventsPost_CustomsFieldsNotProvided() {
-        //  Create new audit event message with no custom fields specified.
-        NewAuditEvent auditEventMessage = createNewAuditEventExcludeCustomFields();
-        try {
-            auditEventsApi.auditeventsPost(auditEventMessage);
-        } catch (ApiException ae) {
-            Assert.assertEquals(ae.getMessage(),"Custom audit event fields have not been specified");
         }
     }
 

--- a/caf-audit-service-container/src/main/resources/server.xml
+++ b/caf-audit-service-container/src/main/resources/server.xml
@@ -1,0 +1,151 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+
+    Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+    <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+    <!-- Security listener. Documentation at /docs/config/listeners.html
+    <Listener className="org.apache.catalina.security.SecurityListener" />
+    -->
+    <!--APR library loader. Documentation at /docs/apr.html -->
+    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+    <!-- Global JNDI resources
+         Documentation at /docs/jndi-resources-howto.html
+    -->
+    <GlobalNamingResources>
+        <!-- Editable user database that can also be used by
+             UserDatabaseRealm to authenticate users
+        -->
+        <Resource name="UserDatabase" auth="Container"
+                  type="org.apache.catalina.UserDatabase"
+                  description="User database that can be updated and saved"
+                  factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+                  pathname="conf/tomcat-users.xml" />
+    </GlobalNamingResources>
+
+    <!-- A "Service" is a collection of one or more "Connectors" that share
+         a single "Container" Note:  A "Service" is not itself a "Container",
+         so you may not define subcomponents such as "Valves" at this level.
+         Documentation at /docs/config/service.html
+     -->
+    <Service name="Catalina">
+
+        <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+        <!--
+        <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+            maxThreads="150" minSpareThreads="4"/>
+        -->
+
+        <!-- A "Connector" represents an endpoint by which requests are received
+             and responses are returned. Documentation at :
+             Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+             Java AJP  Connector: /docs/config/ajp.html
+             APR (HTTP/AJP) Connector: /docs/apr.html
+             Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+        -->
+        <Connector port="8080" protocol="HTTP/1.1"
+                   connectionTimeout="20000"
+                   redirectPort="8443" />
+        <!-- A "Connector" using the shared thread pool-->
+        <!--
+        <Connector executor="tomcatThreadPool"
+                   port="8080" protocol="HTTP/1.1"
+                   connectionTimeout="20000"
+                   redirectPort="8443" />
+        -->
+
+        <!-- A connector with SSL enabled. The commenting lines below will be removed by the
+             setup-tomcat-ssl-cert.sh script. This connector uses the NIO implementation that requires the JSSE
+             style configuration. When using the APR/native implementation, the
+             OpenSSL style configuration is required as described in the APR/native
+             documentation -->
+        <!-- setup-tomcat-ssl-cert.sh TLS section start
+        <Connector port="8443"
+            protocol="org.apache.coyote.http11.Http11NioProtocol"
+            SSLEnabled="true"
+            scheme="https"
+            secure="true"
+            keystoreFile="/keystore/tomcat.keystore"
+            keystorePass="changeit"
+            keyPass="changeit"
+            clientAuth="false"
+            keyAlias="tomcat"
+            sslProtocol="TLS" />
+            setup-tomcat-ssl-cert.sh TLS section end -->
+
+        <!-- Define an AJP 1.3 Connector on port 8009 -->
+        <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+
+
+        <!-- An Engine represents the entry point (within Catalina) that processes
+             every request.  The Engine implementation for Tomcat stand alone
+             analyzes the HTTP headers included with the request, and passes them
+             on to the appropriate Host (virtual host).
+             Documentation at /docs/config/engine.html -->
+
+        <!-- You should set jvmRoute to support load-balancing via AJP ie :
+        <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+        -->
+        <Engine name="Catalina" defaultHost="localhost">
+
+            <!--For clustering, please take a look at documentation at:
+                /docs/cluster-howto.html  (simple how to)
+                /docs/config/cluster.html (reference documentation) -->
+            <!--
+            <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+            -->
+
+            <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+                 via a brute-force attack -->
+            <Realm className="org.apache.catalina.realm.LockOutRealm">
+                <!-- This Realm uses the UserDatabase configured in the global JNDI
+                     resources under the key "UserDatabase".  Any edits
+                     that are performed against this UserDatabase are immediately
+                     available for use by the Realm.  -->
+                <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+                       resourceName="UserDatabase"/>
+            </Realm>
+
+            <Host name="localhost"  appBase="webapps"
+                  unpackWARs="true" autoDeploy="true">
+
+                <!-- SingleSignOn valve, share authentication between web applications
+                     Documentation at: /docs/config/valve.html -->
+                <!--
+                <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+                -->
+
+                <!-- Access log processes all example.
+                     Documentation at: /docs/config/valve.html
+                     Note: The pattern used is equivalent to using pattern="common" -->
+                <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+                       prefix="localhost_access_log" suffix=".txt"
+                       pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+            </Host>
+        </Engine>
+    </Service>
+</Server>

--- a/caf-audit-service-container/start.sh
+++ b/caf-audit-service-container/start.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
 #
@@ -14,4 +15,11 @@
 # limitations under the License.
 #
 
-sh $CATALINA_HOME/bin/catalina.sh run
+# Check if the SSL_TOMCAT_CA_CERT_LOCATION environment variable is set, if so, run the setup-tomcat-ssl-cert.sh script.
+if [ -n "${SSL_TOMCAT_CA_CERT_LOCATION}" ]
+then
+    echo "Tomcat CA Cert provided at location: ${SSL_TOMCAT_CA_CERT_LOCATION}"
+    /container-cert-script/setup-tomcat-ssl-cert.sh
+fi
+
+$CATALINA_HOME/bin/catalina.sh run

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
-        <version>1.9.0-197</version>
+        <version>1.10.0-205</version>
         <relativePath />
     </parent>
 

--- a/release-notes-3.1.0.md
+++ b/release-notes-3.1.0.md
@@ -1,7 +1,6 @@
-!not-ready-for-release!
 
 #### Version Number
-${version-number}
+- [CAF-2277](https://jira.autonomy.com/browse/CAF-2277): Exposed a new https endpoint for audit web service web calls (default 8443).
 
 #### New Features
 


### PR DESCRIPTION
HTTPS changes now ready for review. Please note I wrongly named the initial commit in this branch so please ignore CAF-2693 as it should read CAF-2277: Add HTTPS support to the audit web service.