### PR TITLE
CAF-2850: ElasticAuditConfiguration should be configurable via Sys-Props Or Env-Vars

### DIFF
--- a/caf-audit/src/main/java/com/hpe/caf/auditing/AuditConnectionFactory.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/AuditConnectionFactory.java
@@ -58,4 +58,18 @@ public class AuditConnectionFactory {
                 throw new RuntimeException("Unknown CAF_AUDIT_MODE specified");
         }
     }
+
+    /**
+     * Create connection for the Audit application. Returns NoopAuditConnection if an 'CAF_AUDIT_MODE' environment
+     * variable has not been set. If 'CAF_AUDIT_MODE' has been set to 'direct' this returns an ElasticAuditConnection
+     * if its required system properties or environment variables for configuration have been set.
+     *
+     * @return the connection to the audit server, depending on the setting of the 'CAF_AUDIT_MODE' environment variable
+     * @throws ConfigurationException if the configuration details cannot be retrieved from system properties or
+     * environment variables for building ElasticAuditConfiguration.
+     * @throws WebServiceClientException if 'CAF_AUDIT_MODE' has been set to webservice.
+     */
+    public static AuditConnection createConnection() throws WebServiceClientException, ConfigurationException {
+        return createConnection(null);
+    }
 }

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConfiguration.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConfiguration.java
@@ -20,9 +20,9 @@ import com.hpe.caf.api.Configuration;
 @Configuration
 public class ElasticAuditConfiguration {
 
-    private static String DEFAULT_CLUSTER_NAME = "elasticsearch-cluster";
-    private static int DEFAULT_NUMBER_OF_SHARDS = 5;
-    private static int DEFAULT_NUMBER_OF_REPLICAS = 1;
+    private static String DEFAULT_CLUSTER_NAME = ElasticAuditConstants.ConfigDefault.CAF_ELASTIC_CLUSTER_NAME;
+    private static int DEFAULT_NUMBER_OF_SHARDS = ElasticAuditConstants.ConfigDefault.CAF_ELASTIC_NUMBER_OF_SHARDS;
+    private static int DEFAULT_NUMBER_OF_REPLICAS = ElasticAuditConstants.ConfigDefault.CAF_ELASTIC_NUMBER_OF_REPLICAS;
 
     public ElasticAuditConfiguration() {
 

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
@@ -35,16 +35,16 @@ public class ElasticAuditConnection implements AuditConnection {
             config = new ElasticAuditConfiguration();
 
             // Get the Elasticsearch host and port values from env var
-            config.setHostAndPortValues(getStringFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_HOST_AND_PORT_VALS_ENV_VAR));
+            config.setHostAndPortValues(System.getProperty(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_HOST_AND_PORT_VALUES, System.getenv(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_HOST_AND_PORT_VALUES)));
 
             // Get the Elasticsearch cluster name from env var
-            config.setClusterName(getStringFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_CLUSTER_NAME_ENV_VAR));
+            config.setClusterName(System.getProperty(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME, System.getenv(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME)));
 
             // Get the Elasticsearch number of shards per index from env var else default to '5'
-            config.setNumberOfShards(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_NUM_OF_SHARDS_ENV_VAR, 5));
+            config.setNumberOfShards(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_SHARDS, 5));
 
             // Get the Elasticsearch number of replicas per shard from env var else default to '1'
-            config.setNumberOfReplicas(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_NUM_OF_REPLICAS_ENV_VAR, 1));
+            config.setNumberOfReplicas(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_REPLICAS, 1));
 
         } else {
             config = configSource.getConfiguration(ElasticAuditConfiguration.class);
@@ -60,7 +60,7 @@ public class ElasticAuditConnection implements AuditConnection {
     private static int getNumberFromSysPropertyOrEnvVariable(final String environmentVariable,
                                                              final int defaultTo) throws ConfigurationException {
         try {
-            final String envVarValue = getStringFromSysPropertyOrEnvVariable(environmentVariable);
+            final String envVarValue = System.getProperty(environmentVariable, System.getenv(environmentVariable));
             if (envVarValue != null) {
                 return Integer.parseInt(envVarValue);
             }
@@ -69,10 +69,6 @@ public class ElasticAuditConnection implements AuditConnection {
                     "numbers", nfe);
         }
         return defaultTo;
-    }
-
-    private static String getStringFromSysPropertyOrEnvVariable(final String environmentVariable) throws ConfigurationException {
-        return System.getProperty(environmentVariable, System.getenv(environmentVariable));
     }
 
     @Override

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
@@ -30,13 +30,49 @@ public class ElasticAuditConnection implements AuditConnection {
 
     public ElasticAuditConnection(ConfigurationSource configSource) throws ConfigurationException {
         //  Get Elasticsearch configuration.
-        final ElasticAuditConfiguration config = configSource.getConfiguration(ElasticAuditConfiguration.class);
+        final ElasticAuditConfiguration config;
+        if (configSource == null) {
+            config = new ElasticAuditConfiguration();
+
+            // Get the Elasticsearch host and port values from env var
+            config.setHostAndPortValues(getStringFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_HOST_AND_PORT_VALS_ENV_VAR));
+
+            // Get the Elasticsearch cluster name from env var
+            config.setClusterName(getStringFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_CLUSTER_NAME_ENV_VAR));
+
+            // Get the Elasticsearch number of shards per index from env var else default to '5'
+            config.setNumberOfShards(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_NUM_OF_SHARDS_ENV_VAR, 5));
+
+            // Get the Elasticsearch number of replicas per shard from env var else default to '1'
+            config.setNumberOfReplicas(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.ES_NUM_OF_REPLICAS_ENV_VAR, 1));
+
+        } else {
+            config = configSource.getConfiguration(ElasticAuditConfiguration.class);
+        }
 
         //  Get Elasticsearch connection.
         transportClient = ElasticAuditTransportClientFactory.getTransportClient(config.getHostAndPortValues(), config.getClusterName());
 
         //  Get Elasticsearch index manager.
         indexManager = new ElasticAuditIndexManager(config, transportClient);
+    }
+
+    private static int getNumberFromSysPropertyOrEnvVariable(final String environmentVariable,
+                                                             final int defaultTo) throws ConfigurationException {
+        try {
+            final String envVarValue = getStringFromSysPropertyOrEnvVariable(environmentVariable);
+            if (envVarValue != null) {
+                return Integer.parseInt(envVarValue);
+            }
+        } catch (final NumberFormatException nfe) {
+            throw new ConfigurationException(environmentVariable + " environment variable should only contain " +
+                    "numbers", nfe);
+        }
+        return defaultTo;
+    }
+
+    private static String getStringFromSysPropertyOrEnvVariable(final String environmentVariable) throws ConfigurationException {
+        return System.getProperty(environmentVariable, System.getenv(environmentVariable));
     }
 
     @Override

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
@@ -40,15 +40,15 @@ public class ElasticAuditConnection implements AuditConnection {
             // Get the Elasticsearch cluster name from env var else default to "elasticsearch-cluster"
             String clusterName = System.getProperty(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME, System.getenv(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME));
             if (clusterName == null) {
-                clusterName = "elasticsearch-cluster";
+                clusterName = ElasticAuditConstants.ConfigDefault.CAF_ELASTIC_CLUSTER_NAME;
             }
             config.setClusterName(clusterName);
 
             // Get the Elasticsearch number of shards per index from env var else default to '5'
-            config.setNumberOfShards(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_SHARDS, 5));
+            config.setNumberOfShards(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_SHARDS, ElasticAuditConstants.ConfigDefault.CAF_ELASTIC_NUMBER_OF_SHARDS));
 
             // Get the Elasticsearch number of replicas per shard from env var else default to '1'
-            config.setNumberOfReplicas(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_REPLICAS, 1));
+            config.setNumberOfReplicas(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_REPLICAS, ElasticAuditConstants.ConfigDefault.CAF_ELASTIC_NUMBER_OF_REPLICAS));
 
         } else {
             config = configSource.getConfiguration(ElasticAuditConfiguration.class);

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConnection.java
@@ -37,8 +37,12 @@ public class ElasticAuditConnection implements AuditConnection {
             // Get the Elasticsearch host and port values from env var
             config.setHostAndPortValues(System.getProperty(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_HOST_AND_PORT_VALUES, System.getenv(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_HOST_AND_PORT_VALUES)));
 
-            // Get the Elasticsearch cluster name from env var
-            config.setClusterName(System.getProperty(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME, System.getenv(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME)));
+            // Get the Elasticsearch cluster name from env var else default to "elasticsearch-cluster"
+            String clusterName = System.getProperty(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME, System.getenv(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_CLUSTER_NAME));
+            if (clusterName == null) {
+                clusterName = "elasticsearch-cluster";
+            }
+            config.setClusterName(clusterName);
 
             // Get the Elasticsearch number of shards per index from env var else default to '5'
             config.setNumberOfShards(getNumberFromSysPropertyOrEnvVariable(ElasticAuditConstants.ConfigEnvVar.CAF_ELASTIC_NUMBER_OF_SHARDS, 5));

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConstants.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConstants.java
@@ -53,10 +53,10 @@ public final class ElasticAuditConstants {
     }
 
     public final static class ConfigEnvVar {
-        public static final String ES_HOST_AND_PORT_VALS_ENV_VAR = "CAF_ELASTIC_HOST_AND_PORT_VALUES";
-        public static final String ES_CLUSTER_NAME_ENV_VAR = "CAF_ELASTIC_CLUSTER_NAME";
-        public static final String ES_NUM_OF_SHARDS_ENV_VAR = "CAF_ELASTIC_NUMBER_OF_SHARDS";
-        public static final String ES_NUM_OF_REPLICAS_ENV_VAR = "CAF_ELASTIC_NUMBER_OF_REPLICAS";
+        public static final String CAF_ELASTIC_HOST_AND_PORT_VALUES = "CAF_ELASTIC_HOST_AND_PORT_VALUES";
+        public static final String CAF_ELASTIC_CLUSTER_NAME = "CAF_ELASTIC_CLUSTER_NAME";
+        public static final String CAF_ELASTIC_NUMBER_OF_SHARDS = "CAF_ELASTIC_NUMBER_OF_SHARDS";
+        public static final String CAF_ELASTIC_NUMBER_OF_REPLICAS = "CAF_ELASTIC_NUMBER_OF_REPLICAS";
     }
 
 }

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConstants.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConstants.java
@@ -59,4 +59,10 @@ public final class ElasticAuditConstants {
         public static final String CAF_ELASTIC_NUMBER_OF_REPLICAS = "CAF_ELASTIC_NUMBER_OF_REPLICAS";
     }
 
+    public final static class ConfigDefault {
+        public static final String CAF_ELASTIC_CLUSTER_NAME = "elasticsearch-cluster";
+        public static final int CAF_ELASTIC_NUMBER_OF_SHARDS = 5;
+        public static final int CAF_ELASTIC_NUMBER_OF_REPLICAS = 1;
+    }
+
 }

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConstants.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditConstants.java
@@ -52,4 +52,11 @@ public final class ElasticAuditConstants {
         public static final String DATE_SUFFIX = "_CADte";
     }
 
+    public final static class ConfigEnvVar {
+        public static final String ES_HOST_AND_PORT_VALS_ENV_VAR = "CAF_ELASTIC_HOST_AND_PORT_VALUES";
+        public static final String ES_CLUSTER_NAME_ENV_VAR = "CAF_ELASTIC_CLUSTER_NAME";
+        public static final String ES_NUM_OF_SHARDS_ENV_VAR = "CAF_ELASTIC_NUMBER_OF_SHARDS";
+        public static final String ES_NUM_OF_REPLICAS_ENV_VAR = "CAF_ELASTIC_NUMBER_OF_REPLICAS";
+    }
+
 }

--- a/caf-audit/src/test/java/com/hpe/caf/auditing/elastic/ElasticAuditIT.java
+++ b/caf-audit/src/test/java/com/hpe/caf/auditing/elastic/ElasticAuditIT.java
@@ -22,6 +22,7 @@ import com.hpe.caf.auditing.AuditChannel;
 import com.hpe.caf.auditing.AuditConnectionHelper;
 import com.hpe.caf.auditing.AuditEventBuilder;
 import com.hpe.caf.auditing.AuditIndexingHint;
+import com.hpe.caf.auditing.AuditConnectionFactory;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -185,7 +186,7 @@ public class ElasticAuditIT
         System.setProperty(ElasticAuditConstants.ConfigEnvVar.ES_HOST_AND_PORT_VALS_ENV_VAR, esHostAndPort);
         System.setProperty(ElasticAuditConstants.ConfigEnvVar.ES_CLUSTER_NAME_ENV_VAR, ES_CLUSTERNAME);
 
-        try (final AuditConnection auditConnection = new ElasticAuditConnection(null);
+        try (final AuditConnection auditConnection = AuditConnectionFactory.createConnection();
              com.hpe.caf.auditing.AuditChannel auditChannel = auditConnection.createChannel()) {
 
             // Send Audit Event to Elasticsearch

--- a/docs/pages/en-us/Client-API.md
+++ b/docs/pages/en-us/Client-API.md
@@ -19,7 +19,7 @@ This section covers `caf-audit` library classes and how to use them as objects w
 
 The order of instantiation and use of these objects for sending audit events is as follows:
 
-1. If you do not have an existing [`ConfigurationSource`](#ConfigurationSource) object, create one for retrieving and holding configuration details for the mode you require.
+1. If you do not have an existing [`ConfigurationSource`](#ConfigurationSource) object, create one for retrieving and holding configuration details for the mode you require. Optionally, [Direct to Elasticsearch](#direct-to-elasticsearch-configuration) mode can be configured via system or environment variables.
 2. Use the [`AuditConnectionFactory`](#AuditConnectionFactory) to create the [`AuditConnection`](#AuditConnection) object by setting the [`CAF_AUDIT_MODE Environment Variable`](#CAF_AUDIT_MODE-environment-variable) and pass it the [`ConfigurationSource`](#ConfigurationSource).
 3. Create an [`AuditChannel`](#AuditChannel) object from the [`AuditConnection`](#AuditConnection) object.
 4. Use the [`AuditEventBuilder`](#AuditEventBuilder) object to construct and send audit event messages to the endpoint.
@@ -35,7 +35,7 @@ You may already have a CAF configuration source in your application. It is a gen
 - a REST service
 - a custom source that better integrates with the host application.
 
-A `ConfigurationSource` object is required for the [`AuditConnectionFactory`](#AuditConnectionFactory) object to produce an [`AuditConnection`](#AuditConnection) object.
+A `ConfigurationSource` object is required for the [`AuditConnectionFactory`](#AuditConnectionFactory) object `createConnection(ConfigurationSource configSource)` method to produce an [`AuditConnection`](#AuditConnection) object.
 
 If you're not already using CAF's configuration mechanism, this sample code illustrates the generation of a `ConfigurationSource` object.
 
@@ -107,9 +107,13 @@ To use JSON-encoded files for your configuration, add the following additional d
 	    <scope>runtime</scope>
 	</dependency>
 
-#### Direct to Elasticsearch Configuration
+### Direct to Elasticsearch Configuration
 
-In the [`ConfigurationSource`](#ConfigurationSource) above, we used JSON-encoded files with the following parameters:
+Direct to Elasticsearch mode can be configured with a [`ConfigurationSource`](#ConfigurationSource) object or via environment variables
+
+#### Direct to Elasticsearch ConfigurationSource
+
+In the [`ConfigurationSource`](#ConfigurationSource) section, we used JSON-encoded files with the following parameters:
 
 - `CAF_CONFIG_PATH: /etc/sampleapp/config`
 - `CAF_APPNAME: sampleappgroup/sampleapp`
@@ -130,9 +134,18 @@ where:
 - `numberOfShards` the number of primary shards that an index should have. Defaults to 5.
 - `numberOfReplicas` the number of replica shards (copies) that each primary shard should have. Defaults to 1.
 
-#### Audit Web Service Client Configuration
+#### Direct to Elasticsearch Environment Variables
 
-In the [`ConfigurationSource`](#ConfigurationSource) above, we used JSON-encoded files with the following parameters:
+As an alternative to creating a [`ConfigurationSource`](#ConfigurationSource), for the `ElasticAuditConnection` or [`AuditConnectionFactory`](#AuditConnectionFactory), the direct to Elasticsearch mode can be configured via the following environment variables:
+
+- `CAF_ELASTIC_HOST_AND_PORT_VALUES` refers to one or more of the nodes of the Elasticsearch cluster as a comma-separated list.
+- `CAF_ELASTIC_CLUSTER_NAME` name of the Elasticsearch cluster. Defaults to "elasticsearch-cluster".
+- `CAF_ELASTIC_NUMBER_OF_SHARDS` the number of primary shards that an index should have. Defaults to 5.
+- `CAF_ELASTIC_NUMBER_OF_REPLICAS` the number of replica shards (copies) that each primary shard should have. Defaults to 1.
+
+### Audit Web Service Client Configuration
+
+In the [`ConfigurationSource`](#ConfigurationSource) section, we used JSON-encoded files with the following parameters:
 
 - `CAF_CONFIG_PATH: /etc/sampleapp/config`
 - `CAF_APPNAME: sampleappgroup/sampleapp`

--- a/docs/pages/en-us/Getting-Started.md
+++ b/docs/pages/en-us/Getting-Started.md
@@ -239,7 +239,13 @@ Regardless of whether you choose to use a generated client-side library, or to u
 
 This object represents a logical connection to the datastore (that is, Elasticsearch in the current implementation). It is a thread-safe object. ***Please take into account that this object requires some time to construct. The application should hold on to it and re-use it, rather than constantly re-construct it.***
 
-The `AuditConnection` object can be constructed using the static `createConnection()` method in the `AuditConnectionFactory` class. This method takes a `ConfigurationSource` parameter, which is the standard method of configuration in CAF.
+The `AuditConnection` object, for direct to Elasticseach, can be constructed by setting the `CAF_AUDIT_MODE` environment variable to `direct` and then using one of the static `createConnection()` methods in the `AuditConnectionFactory` class:
+- `createConnection(ConfigurationSource configSource)` method takes a [`ConfigurationSource`](#configurationsource) parameter, which is the standard method of configuration in CAF. 
+- `createConnection()` method has no parameters and requires the following environment variables to be set when creating a connection for direct to Elasticsearch:
+	- `CAF_ELASTIC_HOST_AND_PORT_VALUES` refers to one or more of the nodes of the Elasticsearch cluster as a comma-separated list.
+	- `CAF_ELASTIC_CLUSTER_NAME` name of the Elasticsearch cluster. Defaults to "elasticsearch-cluster".
+	- `CAF_ELASTIC_NUMBER_OF_SHARDS` the number of primary shards that an index should have. Defaults to 5.
+	- `CAF_ELASTIC_NUMBER_OF_REPLICAS` the number of replica shards (copies) that each primary shard should have. Defaults to 1.
 
 #### ConfigurationSource
 


### PR DESCRIPTION
If the ElasticAuditConnection is passed a null ConfigurationSource it builds up configuration settings from system props or environment variables. If number of shards is not passed through sys-prop or env-var it defaults to 5 and number of replicas defaults to 1.