### PR TITLE
CAF-2992: Audit to ES cluster issues

### DIFF
--- a/caf-audit-service-container/src/integration-test/java/com/hpe/caf/services/audit/api/WebserviceClientAuditIT.java
+++ b/caf-audit-service-container/src/integration-test/java/com/hpe/caf/services/audit/api/WebserviceClientAuditIT.java
@@ -40,6 +40,7 @@ import org.elasticsearch.search.SearchHits;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
@@ -54,13 +55,13 @@ public class WebserviceClientAuditIT {
     private static final Logger LOG = LogManager.getLogger(WebserviceClientAuditIT.class.getName());
 
     private static final String APPLICATION_ID = "aTestApplication";
-    private static final String TENANT_ID = "tTestTenant";
+    private static String TENANT_ID;
     private static final String USER_ID = "aTestUser@testcompany.com";
     private static final String EVENT_CATEGORY_ID = "evDocument";
     private static final String EVENT_TYPE_ID = "etView";
     private static final String CORRELATION_ID = "cTestCorrelation";
 
-    private static final String ES_INDEX = TENANT_ID + ElasticAuditConstants.Index.SUFFIX;
+    private static String ES_INDEX;
 
     private static final String CUSTOM_DOC_STRING_PARAM_FIELD = "docStringParam";
     private static final String CUSTOM_DOC_INT_PARAM_FIELD = "docIntParam";
@@ -117,6 +118,12 @@ public class WebserviceClientAuditIT {
         ES_PORT = Integer.parseInt(System.getProperty("elasticsearch.transport.port", System.getenv("elasticsearch.transport.port")));
         ES_CLUSTERNAME = System.getProperty("CAF_ELASTIC_CLUSTER_NAME", System.getenv("CAF_ELASTIC_CLUSTER_NAME"));
         ES_HOSTNAME_AND_PORT = String.format("%s:%s", ES_HOSTNAME, ES_PORT);
+    }
+
+    @BeforeMethod
+    public void randomiseTenantId() {
+        TENANT_ID = UUID.randomUUID().toString().replace("-", "");
+        ES_INDEX = TENANT_ID + ElasticAuditConstants.Index.SUFFIX;
     }
 
     @AfterMethod

--- a/caf-audit-service/src/main/java/com/hpe/caf/services/audit/server/api/impl/AuditeventsApiServiceImpl.java
+++ b/caf-audit-service/src/main/java/com/hpe/caf/services/audit/server/api/impl/AuditeventsApiServiceImpl.java
@@ -83,6 +83,8 @@ public class AuditeventsApiServiceImpl extends AuditeventsApiService {
     private static final String EVENT_PARAM_INDEXING_HINT_FULLTEXT = "FULLTEXT";
     private static final String EVENT_PARAM_INDEXING_HINT_KEYWORD = "KEYWORD";
 
+    private AuditConnection auditConnection;
+
     @Override
     public Response auditeventsPost(NewAuditEvent newAuditEvent, SecurityContext securityContext) throws NotFoundException {
         //  Index new audit event into Elasticsearch.
@@ -106,9 +108,13 @@ public class AuditeventsApiServiceImpl extends AuditeventsApiService {
         //  Validate the incoming new audit event parameter.
         validateNewAuditEventFields(newAuditEvent);
 
+        // If an AuditConnection has been been established create one with the ConfigurationSource.
+        if (auditConnection == null) {
+            auditConnection = AuditConnectionFactory.createConnection(getConfigurationSource());
+        }
+
         //  Index audit event message into Elasticsearch.
         try (
-                AuditConnection auditConnection = AuditConnectionFactory.createConnection(getConfigurationSource());
                 AuditChannel auditChannel = auditConnection.createChannel()
         ) {
             LOG.debug("AuditConnection and AuditChannel created");

--- a/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditTransportClientFactory.java
+++ b/caf-audit/src/main/java/com/hpe/caf/auditing/elastic/ElasticAuditTransportClientFactory.java
@@ -52,14 +52,19 @@ public class ElasticAuditTransportClientFactory {
      */
     public static TransportClient getTransportClient(String hostAndPortValues, String clusterName) throws ConfigurationException {
         final TransportClient transportClient;
-        Settings settings = Settings.builder()
-                .put("cluster.name", clusterName)
-                .put("client.transport.sniff", true).build();
-        transportClient = new PreBuiltTransportClient(settings);
 
         if (hostAndPortValues != null && !hostAndPortValues.isEmpty()) {
             //  Split comma separated list of ES hostname and port values.
             final String[] hostAndPortArray = hostAndPortValues.split(",");
+
+            // If there is more than one Elasticsearch host then set the client.transport.sniff to true as we are dealing with a cluster
+            Settings.Builder settingsBuilder = Settings.builder()
+                    .put("cluster.name", clusterName);
+            if (hostAndPortArray.length > 1) {
+                settingsBuilder.put("client.transport.sniff", true);
+            }
+            Settings settings = settingsBuilder.build();
+            transportClient = new PreBuiltTransportClient(settings);
 
             //  For each ES hostname and port, add a transport address that will be used to connect to.
             for (final String hostAndPort : hostAndPortArray) {

--- a/caf-audit/src/test/java/com/hpe/caf/auditing/elastic/ElasticAuditIT.java
+++ b/caf-audit/src/test/java/com/hpe/caf/auditing/elastic/ElasticAuditIT.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -48,13 +49,13 @@ public class ElasticAuditIT
 {
 
     private static final String APPLICATION_ID = "aTestApplication";
-    private static final String TENANT_ID = "tTestTenant";
+    private static String TENANT_ID;
     private static String USER_ID;
     private static final String EVENT_CATEGORY_ID = "evDocument";
     private static final String EVENT_TYPE_ID = "etView";
     private static final String CORRELATION_ID = "cTestCorrelation";
 
-    private static final String ES_INDEX = TENANT_ID + ElasticAuditConstants.Index.SUFFIX;
+    private static String ES_INDEX;
 
     private static final String CUSTOM_DOC_STRING_PARAM_FIELD = "docStringParam";
     private static final String CUSTOM_DOC_STRING_KEYWORD_PARAM_FIELD = "docKeywordParam";
@@ -81,6 +82,12 @@ public class ElasticAuditIT
         ES_PORT = Integer.parseInt(System.getProperty("es.port", System.getenv("es.port")));
         ES_CLUSTERNAME = System.getProperty("es.cluster.name", System.getenv("es.cluster.name"));
         USER_ID = UUID.randomUUID().toString();
+    }
+
+    @Before
+    public void randomiseTenantId() {
+        TENANT_ID = UUID.randomUUID().toString().replace("-", "");
+        ES_INDEX = TENANT_ID + ElasticAuditConstants.Index.SUFFIX;
     }
 
     @Test(expected = ConfigurationException.class)


### PR DESCRIPTION
- The Web Service now creates an instance of the AuditConnection and holds onto it for future audit events
- Adjusted logic that adds elasticsearch hosts to transport client to print warning if a host is unavailable. Added client.transport.sniff transport client setting so that the transport client manages the nodes that become available and unavailable via the state of the cluster.
- Set transport client settings to sniff for other nodes in the cluster if there is more than one host passed (if it is a cluster setup).
- Modified integration tests to randomize the tenant id used before each test