### PR TITLE
CAF-3615 fixing failing test

### DIFF
--- a/caf-audit-maven-plugin/src/test/resources/transform/AuditLog.java
+++ b/caf-audit-maven-plugin/src/test/resources/transform/AuditLog.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
  *


### PR DESCRIPTION
I had to replace a blank line at the start of the AuditLog.java file that had previously been removed by the maven license plugin