### PR TITLE
CAF-4049: Use CAF_AUDIT_MONKEY_JAVA_OPTS in startup

### DIFF
--- a/caf-audit-monkey-container/start.sh
+++ b/caf-audit-monkey-container/start.sh
@@ -17,4 +17,4 @@
 
 
 cd /maven
-java -cp "*" com.github.cafaudit.auditmonkey.AuditMonkey
+java $CAF_AUDIT_MONKEY_JAVA_OPTS -cp "*" com.github.cafaudit.auditmonkey.AuditMonkey


### PR DESCRIPTION
@dermot-hardy Wasn't sure about the name to use here. Does it need added to the documentation as it is specific to the audit monkey?