### PR TITLE
SCMOD-7585: ES cluster name specification removed

### DIFF
--- a/caf-audit-service-container/README.md
+++ b/caf-audit-service-container/README.md
@@ -17,9 +17,6 @@ This is the alternative configuration for REST port of the Elasticsearch server 
 
 Note: `CAF_ELASTIC_HOST_AND_PORT_VALUES` will take precedence over `CAF_ELASTIC_HOST_VALUES` and `CAF_ELASTIC_PORT_VALUE` if all three environment variables have values.
 
-##### CAF\_ELASTIC\_CLUSTER\_NAME
-Name of the Elasticsearch cluster. e.g. docker-cluster. Default value: elasticsearch-cluster.
-
 ##### CAF\_ELASTIC\_NUMBER\_OF\_SHARDS
 The number of primary shards that an Elasticsearch index should have. e.g. 5. Default value: 5.
 

--- a/deploy/src/main/resources-filtered/production-marathon/production-smoke-testing/README.md
+++ b/deploy/src/main/resources-filtered/production-marathon/production-smoke-testing/README.md
@@ -17,7 +17,7 @@ Further information on the CAF Audit Monkey can be found [here](https://github.c
 From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [directtestid], [direct] to Elasticsearch in [Standard] mode using [1] thread. Replace the `ES_HOSTNAME`, `ES_PORT` and `ES_CLUSTERNAME` environment variables with the details of the Elasticsearch deployed for smoke testing purposes:
 
 ```
-docker run -e ES_HOSTNAME=<Elasticsearch_Node> -e ES_PORT=<Elasticsearch_Node_Transport_Port> -e ES_CLUSTERNAME=<Elasticsearch_Cluster_Name> -e CAF_AUDIT_TENANT_ID=directtestid -e CAF_AUDIT_MODE=direct -e CAF_AUDIT_MONKEY_MODE=standard -e CAF_AUDIT_MONKEY_NUM_OF_EVENTS=2 -e CAF_AUDIT_MONKEY_NUM_OF_THREADS=1 cafaudit/audit-monkey:${project.version}
+docker run -e ES_HOSTNAME=<Elasticsearch_Node> -e ES_PORT=<Elasticsearch_Node_Transport_Port> -e CAF_AUDIT_TENANT_ID=directtestid -e CAF_AUDIT_MODE=direct -e CAF_AUDIT_MONKEY_MODE=standard -e CAF_AUDIT_MONKEY_NUM_OF_EVENTS=2 -e CAF_AUDIT_MONKEY_NUM_OF_THREADS=1 cafaudit/audit-monkey:${project.version}
 ```
 
 #### Verification of Direct to Elasticsearch Audit Events

--- a/deploy/src/main/resources-filtered/production-marathon/production-smoke-testing/README.md
+++ b/deploy/src/main/resources-filtered/production-marathon/production-smoke-testing/README.md
@@ -14,7 +14,7 @@ Further information on the CAF Audit Monkey can be found [here](https://github.c
 
 ### Sending Audit Events Direct to Elasticsearch
 
-From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [directtestid], [direct] to Elasticsearch in [Standard] mode using [1] thread. Replace the `ES_HOSTNAME`, `ES_PORT` and `ES_CLUSTERNAME` environment variables with the details of the Elasticsearch deployed for smoke testing purposes:
+From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [directtestid], [direct] to Elasticsearch in [Standard] mode using [1] thread. Replace the `ES_HOSTNAME` and `ES_PORT` environment variables with the details of the Elasticsearch deployed for smoke testing purposes:
 
 ```
 docker run -e ES_HOSTNAME=<Elasticsearch_Node> -e ES_PORT=<Elasticsearch_Node_Transport_Port> -e CAF_AUDIT_TENANT_ID=directtestid -e CAF_AUDIT_MODE=direct -e CAF_AUDIT_MONKEY_MODE=standard -e CAF_AUDIT_MONKEY_NUM_OF_EVENTS=2 -e CAF_AUDIT_MONKEY_NUM_OF_THREADS=1 cafaudit/audit-monkey:${project.version}


### PR DESCRIPTION

ES cluster name is removed from documentation as it is not used . Find the corresponding commit for this removal of variable 
https://github.com/CAFAudit/audit-service/commit/7762daaf081c523056fafae8aa5dd026ca1e9b14
