### PR TITLE
US593021: Updated to run on Java 17

### DIFF
--- a/caf-audit-monkey-container/pom.xml
+++ b/caf-audit-monkey-container/pom.xml
@@ -75,7 +75,7 @@
                         <image>
                             <name>${dockerCafAuditOrg}audit-monkey${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-jre11:3</from>
+                                <from>${dockerHubPublic}/cafapi/opensuse-jre17:1</from>
                                 <cmd>
                                     <exec>
                                         <args>/maven/start.sh</args>

--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -292,7 +292,7 @@
                             <alias>audit-service</alias>
                             <name>${dockerCafAuditOrg}audit-service${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-tomcat-jre11:2</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-tomcat-jre17-1.0.0-US600118-SNAPSHOT</from>
                                 <env>
                                     <CAF_ELASTIC_PROTOCOL>http</CAF_ELASTIC_PROTOCOL>
                                     <CAF_AUDIT_MODE>elasticsearch</CAF_AUDIT_MODE>

--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -292,7 +292,7 @@
                             <alias>audit-service</alias>
                             <name>${dockerCafAuditOrg}audit-service${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-tomcat-jre17-1.0.0-US600118-SNAPSHOT</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-tomcat-jre17-1.0.0-SNAPSHOT</from>
                                 <env>
                                     <CAF_ELASTIC_PROTOCOL>http</CAF_ELASTIC_PROTOCOL>
                                     <CAF_AUDIT_MODE>elasticsearch</CAF_AUDIT_MODE>

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,6 @@
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
-                <classifier>no_aop</classifier>
                 <version>5.1.0</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <classifier>no_aop</classifier>
-                <version>4.2.3</version>
+                <version>5.1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.j2objc</groupId>

--- a/release-notes-3.10.0.md
+++ b/release-notes-3.10.0.md
@@ -4,7 +4,7 @@
 ${version-number}
 
 #### New Features
-- None
+- US593021: Updated to run on Java 17.
 
 #### Patch Fixes Included
 - US572082 - Gson version upgraded to [2.9.1](https://github.com/google/gson/releases/tag/gson-parent-2.9.1)

--- a/release-notes-3.10.0.md
+++ b/release-notes-3.10.0.md
@@ -9,7 +9,7 @@ ${version-number}
 #### Patch Fixes Included
 - US572082: Gson version upgraded to [2.9.1](https://github.com/google/gson/releases/tag/gson-parent-2.9.1)
 - US572083: Snakeyaml version upgraded to [1.32](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
-- US593021: Guice verson updated to [5.1.0](https://github.com/google/guice/releases/tag/5.1.0) to support Java 11.
+- US593021: Guice verson updated to [5.1.0](https://github.com/google/guice/releases/tag/5.1.0) to support Java 17.
 
 #### Known Issues
 - None

--- a/release-notes-3.10.0.md
+++ b/release-notes-3.10.0.md
@@ -7,8 +7,9 @@ ${version-number}
 - US593021: Updated to run on Java 17.
 
 #### Patch Fixes Included
-- US572082 - Gson version upgraded to [2.9.1](https://github.com/google/gson/releases/tag/gson-parent-2.9.1)
-- US572083 -Snakeyaml version upgraded to [1.32](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
+- US572082: Gson version upgraded to [2.9.1](https://github.com/google/gson/releases/tag/gson-parent-2.9.1)
+- US572083: Snakeyaml version upgraded to [1.32](https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes)
+- US593021: Guice verson updated to [5.1.0](https://github.com/google/guice/releases/tag/5.1.0) to support Java 11.
 
 #### Known Issues
 - None


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=593021

Also updated guice as Java 17 was only introduce in 5.1.0: https://github.com/google/guice/wiki/Guice510#changes-since-guice-501