### PR TITLE
866042: Update to latest tomcat base image patch SNAPSHOT

### DIFF
--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -292,7 +292,7 @@
                             <alias>audit-service</alias>
                             <name>${dockerCafAuditOrg}audit-service${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-tomcat-jre17-1.7.0-860022-SNAPSHOT</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-tomcat-jre17-1.6.1-SNAPSHOT</from>
                                 <env>
                                     <CAF_ELASTIC_PROTOCOL>http</CAF_ELASTIC_PROTOCOL>
                                     <CAF_AUDIT_MODE>elasticsearch</CAF_AUDIT_MODE>

--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -292,7 +292,7 @@
                             <alias>audit-service</alias>
                             <name>${dockerCafAuditOrg}audit-service${dockerProjectVersion}</name>
                             <build>
-                                <from>${dockerHubPublic}/cafapi/opensuse-tomcat-jre17:1</from>
+                                <from>${dockerHubPublic}/cafapi/prereleases:opensuse-tomcat-jre17-1.7.0-860022-SNAPSHOT</from>
                                 <env>
                                     <CAF_ELASTIC_PROTOCOL>http</CAF_ELASTIC_PROTOCOL>
                                     <CAF_AUDIT_MODE>elasticsearch</CAF_AUDIT_MODE>


### PR DESCRIPTION
Move to the latest tomcat base image patch SNAPSHOT, which replaces the sed command used to replace passwords in setup-tomcat-ssl-cert.sh with awk, as the sed command failed when the password contained the @ symbol.

Note, we're using the 1.6.1 patch SNAPSHOT, which is still on tomcat 9. The latest main branch SNAPSHOT is on tomcat 10, and I don't think this repo is ready to be moved to that yet.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=866042