### PR TITLE
US860181: Use dynamic name for container

### DIFF
--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -400,7 +400,7 @@
                             <name>docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2</name>
                             <run>
                                 <hostname>elasticsearch</hostname>
-                                <namingStrategy>alias</namingStrategy>
+                                <containerNamePattern>%a-%t</containerNamePattern>
                                 <ports>
                                     <port>${elasticsearch.http.port}:9200</port>
                                 </ports>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=860181

Set container name format to `aliasName-timestamp`. 
For example: `elasticsearch-1704186402611`