### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/caf-audit-binding-elasticsearch/pom.xml
+++ b/caf-audit-binding-elasticsearch/pom.xml
@@ -25,6 +25,7 @@
         <version>5.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>caf-audit-binding-elasticsearch</artifactId>
+    <name>caf-audit-binding-elasticsearch</name>
 
     <dependencies>
         <!-- Compile time dependencies -->

--- a/caf-audit-binding-webservice/pom.xml
+++ b/caf-audit-binding-webservice/pom.xml
@@ -25,6 +25,7 @@
         <version>5.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>caf-audit-binding-webservice</artifactId>
+    <name>caf-audit-binding-webservice</name>
 
     <dependencies>
         <dependency>

--- a/caf-audit-maven-plugin/pom.xml
+++ b/caf-audit-maven-plugin/pom.xml
@@ -22,6 +22,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-maven-plugin</artifactId>
+    <name>caf-audit-maven-plugin</name>
     <packaging>maven-plugin</packaging>
 
     <description>

--- a/caf-audit-monkey-auditlog/pom.xml
+++ b/caf-audit-monkey-auditlog/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>caf-audit-monkey-auditlog</artifactId>
+    <name>caf-audit-monkey-auditlog</name>
 
     <parent>
         <groupId>com.github.cafaudit</groupId>

--- a/caf-audit-monkey-container/pom.xml
+++ b/caf-audit-monkey-container/pom.xml
@@ -21,6 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>caf-audit-monkey-container</artifactId>
+    <name>caf-audit-monkey-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/caf-audit-monkey/pom.xml
+++ b/caf-audit-monkey/pom.xml
@@ -21,6 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>caf-audit-monkey</artifactId>
+    <name>caf-audit-monkey</name>
 
     <parent>
         <groupId>com.github.cafaudit</groupId>

--- a/caf-audit-schema/pom.xml
+++ b/caf-audit-schema/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-schema</artifactId>
+    <name>caf-audit-schema</name>
 
     <parent>
         <groupId>com.github.cafaudit</groupId>

--- a/caf-audit-service-container/pom.xml
+++ b/caf-audit-service-container/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-service-container</artifactId>
+    <name>caf-audit-service-container</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/caf-audit-service-contract/pom.xml
+++ b/caf-audit-service-contract/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-service-contract</artifactId>
+    <name>caf-audit-service-contract</name>
 
     <parent>
         <groupId>com.github.cafaudit</groupId>

--- a/caf-audit-service-dropwizard/pom.xml
+++ b/caf-audit-service-dropwizard/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>caf-audit-service-dropwizard</artifactId>
+    <name>caf-audit-service-dropwizard</name>
 
     <properties>
         <debug.argument>-showversion</debug.argument>

--- a/caf-audit-service-internal-testing-client/pom.xml
+++ b/caf-audit-service-internal-testing-client/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>caf-audit-service-internal-testing-client</artifactId>
+    <name>caf-audit-service-internal-testing-client</name>
 
     <dependencies>
         <dependency>

--- a/caf-audit-service-server-stub-source/pom.xml
+++ b/caf-audit-service-server-stub-source/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>caf-audit-service-server-stub-source</artifactId>
+    <name>caf-audit-service-server-stub-source</name>
 
     <dependencies>
         <dependency>

--- a/caf-audit-service-testing-auditlog/pom.xml
+++ b/caf-audit-service-testing-auditlog/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-service-testing-auditlog</artifactId>
+    <name>caf-audit-service-testing-auditlog</name>
 
     <parent>
         <groupId>com.github.cafaudit</groupId>

--- a/caf-audit-service/pom.xml
+++ b/caf-audit-service/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>caf-audit-service</artifactId>
+    <name>caf-audit-service</name>
 
     <dependencies>
         <dependency>

--- a/caf-audit/pom.xml
+++ b/caf-audit/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit</artifactId>
+    <name>caf-audit</name>
 
     <parent>
         <groupId>com.github.cafaudit</groupId>

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-deploy</artifactId>
+    <name>caf-audit-deploy</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.cafaudit</groupId>
     <artifactId>caf-audit-docs</artifactId>
+    <name>caf-audit-docs</name>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210