### PR TITLE
US1021335 - Remove redundant deepcheck-dependencies configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1175,15 +1175,6 @@
                     </ignoreVersions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>deepcheck-dependencies</id>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1181,18 +1181,6 @@
                 <executions>
                     <execution>
                         <id>deepcheck-dependencies</id>
-                        <configuration>
-                            <ignoredResourcePatterns>
-                                <!--
-                                    Unfortunately this is included by both HttpClient 4 and HttpClient 5.
-                                    We're currently using opensearch-rest-client version 2.11.1 which uses HttpClient 4,
-                                    but its main branch has already been updated to HttpClient 5 so we should be able to
-                                    get rid of this exclusion when we move to the next major version.
-                                    Of source this project itself will also have to be moved to HttpClient 5.
-                                -->
-                                <ignoredResourcePattern>^mozilla/public-suffix-list.txt</ignoredResourcePattern>
-                            </ignoredResourcePatterns>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Remove redundant duplicate-finder-maven-plugin configurations. These configurations were used to ignore conflicts between HttpClient 4 and 5, but are no longer needed since HttpClient 5.4. This PR removes these obsolete configuration.